### PR TITLE
Solved Module 'DBD::mysql' is not installed error

### DIFF
--- a/20.05/Dockerfile
+++ b/20.05/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update && apt-get --no-install-recommends -y install \
     make \
     perl \
     pkg-config \
+    libdbd-mysql-perl \
     && rm -rf /var/lib/apt/lists/*
 
 RUN adduser --disabled-password --gecos '' koha


### PR DESCRIPTION
Recently I tried to install Koha 20.05 (I know it's older but installed for client support). And I noticed that this dockerfile missing DBD::mysql installation, that is required to run the software. Now it's fixed and tested.